### PR TITLE
kill unicode literals;clean up;py36 compat

### DIFF
--- a/src/nti/ntiids/__init__.py
+++ b/src/nti/ntiids/__init__.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """
-.. $Id$
+.. $Id: __init__.py 104508 2017-01-17 04:20:48Z carlos.sanchez $
 """
 
-from __future__ import print_function, unicode_literals, absolute_import, division
+from __future__ import print_function, absolute_import, division
 __docformat__ = "restructuredtext en"
 
 logger = __import__('logging').getLogger(__name__)

--- a/src/nti/ntiids/interfaces.py
+++ b/src/nti/ntiids/interfaces.py
@@ -3,10 +3,10 @@
 """
 NTIID related interfaces.
 
-.. $Id$
+.. $Id: interfaces.py 111454 2017-04-26 03:04:41Z carlos.sanchez $
 """
 
-from __future__ import print_function, unicode_literals, absolute_import, division
+from __future__ import print_function, absolute_import, division
 __docformat__ = "restructuredtext en"
 
 logger = __import__('logging').getLogger(__name__)

--- a/src/nti/ntiids/schema.py
+++ b/src/nti/ntiids/schema.py
@@ -3,13 +3,15 @@
 """
 Support for using NTIIDs in a zope schema.
 
-.. $Id$
+.. $Id: schema.py 104508 2017-01-17 04:20:48Z carlos.sanchez $
 """
 
-from __future__ import print_function, unicode_literals, absolute_import, division
+from __future__ import print_function, absolute_import, division
 __docformat__ = "restructuredtext en"
 
 logger = __import__('logging').getLogger(__name__)
+
+import six
 
 from nti.ntiids.ntiids import validate_ntiid_string
 
@@ -23,7 +25,7 @@ class ValidNTIID(ValidURI):
     value is actually reachable or accessibly in a library or catalog.)
     """
 
-    _type = unicode
+    _type = six.text_type
 
     def fromUnicode(self, value):
         # The very first thing the superclass does is turn

--- a/src/nti/ntiids/tests/__init__.py
+++ b/src/nti/ntiids/tests/__init__.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from __future__ import print_function, unicode_literals, absolute_import, division
+from __future__ import print_function, absolute_import, division
 __docformat__ = "restructuredtext en"
 
 # disable: accessing protected members, too many methods
@@ -9,7 +9,6 @@ __docformat__ = "restructuredtext en"
 
 from zope.component.hooks import setHooks
 
-from nti.testing.layers import find_test
 from nti.testing.layers import GCLayerMixin
 from nti.testing.layers import ZopeComponentLayer
 from nti.testing.layers import ConfiguringLayerMixin

--- a/src/nti/ntiids/tests/test_ntiids.py
+++ b/src/nti/ntiids/tests/test_ntiids.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from __future__ import print_function, unicode_literals, absolute_import, division
+from __future__ import print_function, absolute_import, division
 __docformat__ = "restructuredtext en"
 
 # disable: accessing protected members, too many methods


### PR DESCRIPTION
Jason,

Could you check this pull request? This is my attempt to have nti.ntiids running on py27, pypy and py36. I am still unsure if the **make_specific_safe** function is correct (all test pass)

Carlos

