### PR TITLE
Use the correct import for set_external_identifiers.

### DIFF
--- a/src/nti/ntiids/tests/test_oids.py
+++ b/src/nti/ntiids/tests/test_oids.py
@@ -16,7 +16,7 @@ from hamcrest import has_property
 import fudge
 import unittest
 
-from nti.externalization.externalization import set_external_identifiers
+from nti.externalization.extension_points import set_external_identifiers
 
 from nti.ntiids.oids import to_external_ntiid_oid
 from nti.ntiids.oids import setExternalIdentifiers


### PR DESCRIPTION
This is compatible with nti.externalization 1.0a1 forward.